### PR TITLE
Implement request cache with file storage between runs and ttl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 authors = ["Loïc Pelleau <loicpelleau@yahoo.fr>"]
 
 [dependencies]
-hyper = "^0.8.1"
-url = "^0.5.9"
-serde_json = "^0.7.0"
-rand = "^0.3.14"
+hyper = "^0.10"
+url = "^1.5"
+serde_derive = "^1.0"
+serde = "^1.0"
+serde_json = "^1.0"
+rand = "^0.3"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, Duration};
 pub struct Cache<K, V>
     where K: Hash + Eq
 {
-    store: HashMap<K, CachedItem<V>>
+    store: HashMap<K, CachedItem<V>>,
 
     #[serde(default = "default_store_path")]
     #[serde(skip)]
@@ -111,11 +111,20 @@ mod tests {
     }
 
     #[test]
-    fn get_or_compute_dont_compute_when_the_value_is_cached() {
+    fn get_or_compute_doesnt_compute_when_the_value_is_cached() {
         let mut cache = Cache::new();
-        cache.store.insert(1, CachedItem { value: 1 });
+        cache.store.insert(1, CachedItem { value: 1 , expires: SystemTime::now() + Duration::from_secs(3600) });
 
         let result = cache.get_or_compute(1, || panic!());
+        assert!(1 == *result);
+    }
+
+    #[test]
+    fn get_or_compute_computes_when_the_value_is_expired() {
+        let mut cache = Cache::new();
+        cache.store.insert(1, CachedItem { value: 1 , expires: SystemTime::now() - Duration::from_secs(3600) });
+
+        let result = cache.get_or_compute(1, || 1);
         assert!(1 == *result);
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,95 @@
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use std::fs::File;
+use std::io::{Read, Write, Error, ErrorKind};
+use std::path::PathBuf;
+use std::hash::Hash;
+use std::collections::*;
+use serde_json;
+
+#[derive(Serialize, Deserialize)]
+pub struct Cache<K, V>
+    where K: Hash + Eq
+{
+    #[serde(default = "default_store_path")]
+    #[serde(skip)]
+    path: PathBuf,
+    store: HashMap<K, CachedItem<V>>
+}
+
+#[derive(Serialize, Deserialize)]
+struct CachedItem<V> {
+    value: V,
+}
+
+impl<K, V> Cache<K, V>
+    where K: Hash + Eq
+{
+    fn new() -> Self {
+        Cache {
+            path: default_store_path(),
+            store: HashMap::new(),
+        }
+    }
+
+    pub fn get_or_compute<F>(&mut self, key: K, compute: F) -> &mut V
+        where F: FnOnce() -> V
+    {
+        let entry = self.store.entry(key).or_insert_with(|| CachedItem {
+            value: compute(),
+        });
+
+        &mut entry.value
+    }
+
+    pub fn save(&self)
+        where K: Serialize,
+              V: Serialize
+    {
+        let _ = File::create(&self.path)
+            .and_then(|mut file| {
+                serde_json::to_string(&self.store)
+                    .map_err(|err| Error::new(ErrorKind::InvalidData, format!("Can't serialize cache: {}", err)))
+                    .and_then(move |toml| file.write_all(toml.as_bytes()))
+            });
+    }
+
+    pub fn load() -> Self
+        where K: DeserializeOwned,
+              V: DeserializeOwned
+    {
+        File::open(&default_store_path())
+            .and_then(|mut file| {
+                let mut string = String::new();
+                let _          = file.read_to_string(&mut string)?;
+                serde_json::from_str(&string)
+                    .or_else(|err| Err(Error::new(ErrorKind::InvalidData, format!("Can't read configuration file: {}", err))))
+            })
+            .unwrap_or(Cache::new())
+    }
+}
+
+fn default_store_path() -> PathBuf {
+    PathBuf::from("/tmp/ran-git-cache.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_or_compute_computes_when_the_value_is_not_cached() {
+        let mut cache = Cache::new();
+        let result = cache.get_or_compute(1, || 1);
+        assert!(1 == *result);
+    }
+
+    #[test]
+    fn get_or_compute_dont_compute_when_the_value_is_cached() {
+        let mut cache = Cache::new();
+        cache.store.insert(1, CachedItem { value: 1 });
+
+        let result = cache.get_or_compute(1, || panic!());
+        assert!(1 == *result);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,15 @@
 extern crate hyper;
 extern crate url;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
 extern crate serde_json;
 extern crate rand;
 
 mod conf;
 mod request;
 mod work;
+mod cache;
 
 use std::env;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,21 +1,20 @@
-extern crate hyper;
-extern crate url;
-extern crate serde_json;
-
+use serde_json;
 use url::Url;
 use hyper::client::Request;
 use hyper::method::Method;
 use hyper::header;
 use std::io::prelude::*;
+use cache::Cache;
 
 pub struct APIRest {
     url: String,
-    user_agent: String
+    user_agent: String,
+    cache: Cache<String, Result<serde_json::Value, String>>,
 }
 
 impl APIRest {
     pub fn new(url: String) -> APIRest {
-        APIRest { url: url, user_agent: "".to_string() }
+        APIRest { url: url, user_agent: "".to_string(), cache: Cache::load() }
     }
 
     pub fn set_user_agent(&mut self, user_agent: String) -> &APIRest {
@@ -23,39 +22,52 @@ impl APIRest {
         self
     }
 
-    pub fn get(&self, uri: &String) -> Result<serde_json::Value, String> {
-        let url = match Url::parse(format!("{}{}", self.url, uri).as_str()) {
-            Ok(url) => url,
-            Err(err) => return Err(format!("Failed to parse URL: {}", err))
-        };
+    pub fn get(&mut self, uri: &String) -> Result<serde_json::Value, String> {
+        let url = format!("{}{}", self.url, uri);
+        let user_agent = self.user_agent.clone();
 
-        let mut req = match Request::new(Method::Get, url) {
-            Ok(req) => req,
-            Err(err) => return Err(format!("Failed to create Request: {}", err))
-        };
+        let result = self.cache.get_or_compute(url.clone(), || {
+            let url = match Url::parse(url.as_str()) {
+                Ok(url) => url,
+                Err(err) => return Err(format!("Failed to parse URL: {}", err))
+            };
 
-        req.headers_mut().set(header::ContentLength(0u64));
-        req.headers_mut().set(header::UserAgent(self.user_agent.clone()));
+            let mut req = match Request::new(Method::Get, url) {
+                Ok(req) => req,
+                Err(err) => return Err(format!("Failed to create Request: {}", err))
+            };
 
-        let req_started = match req.start() {
-            Ok(req) => req,
-            Err(err) => return Err(format!("Failed to start Request: {}", err))
-        };
+            req.headers_mut().set(header::ContentLength(0u64));
+            req.headers_mut().set(header::UserAgent(user_agent));
 
-        let mut resp = match req_started.send() {
-            Ok(resp) => resp,
-            Err(err) => return Err(format!("Failed to send Request: {}", err))
-        };
+            let req_started = match req.start() {
+                Ok(req) => req,
+                Err(err) => return Err(format!("Failed to start Request: {}", err))
+            };
 
-        let mut resp_body = String::new();
-        match resp.read_to_string(&mut resp_body) {
-            Ok(_) => (),
-            Err(err) => return Err(format!("Failed to parse body to String: {}", err))
-        };
+            let mut resp = match req_started.send() {
+                Ok(resp) => resp,
+                Err(err) => return Err(format!("Failed to send Request: {}", err))
+            };
 
-        match serde_json::from_str(resp_body.as_str()) {
-            Ok(json) => Ok(json),
-            Err(err) => Err(format!("Failed when getting JSON: {:?} (code: {})", err, resp.status))
-        }
+            let mut resp_body = String::new();
+            match resp.read_to_string(&mut resp_body) {
+                Ok(_) => (),
+                Err(err) => return Err(format!("Failed to parse body to String: {}", err))
+            };
+
+            match serde_json::from_str(resp_body.as_str()) {
+                Ok(json) => Ok(json),
+                Err(err) => Err(format!("Failed when getting JSON: {:?} (code: {})", err, resp.status))
+            }
+        });
+
+        result.clone()
+    }
+}
+
+impl Drop for APIRest {
+    fn drop(&mut self) {
+        self.cache.save();
     }
 }

--- a/src/work.rs
+++ b/src/work.rs
@@ -71,7 +71,7 @@ impl Search {
                     let rep = repository.as_object();
 
                     let language = rep.and_then(|object| object.get("language"))
-                        .and_then(|value| value.as_string());
+                        .and_then(|value| value.as_str());
 
                     let lang = language.unwrap_or("").to_string().to_uppercase();
                     if self.options.languages().is_some() && !self.options.languages().unwrap().contains(&lang) {
@@ -79,7 +79,7 @@ impl Search {
                     }
 
                     let full_name = rep.and_then(|object| object.get("full_name"))
-                        .and_then(|value| value.as_string());
+                        .and_then(|value| value.as_str());
                     if let Some(name) = full_name {
                         if self.repositories.contains(&name.to_string()) {
                             continue;
@@ -92,7 +92,7 @@ impl Search {
                         .and_then(|value| value.as_i64());
 
                     let starred = rep.and_then(|object| object.get("html_url"))
-                        .and_then(|value| value.as_string());
+                        .and_then(|value| value.as_str());
 
                     match (stargazers_count, starred) {
                         (Some(count), Some(starred)) => {
@@ -142,7 +142,7 @@ impl Search {
                 for user in following_vec {
                     if let Some(new_login) = user.as_object()
                             .and_then(|object| object.get("login"))
-                            .and_then(|value| value.as_string()) {
+                            .and_then(|value| value.as_str()) {
                         let mut login = login.clone();
                         login.push(new_login.to_string());
 


### PR DESCRIPTION
This implements #1: a cache store used APIRest to store request results.

When creating a APIRest the cache is loaded from the disk if possible.
The cache is written to the disk on when APIRest is dropped.

The cache file is `/tmp/ran-git-cache.json`. The ttl is an hour.
Do you have preferences for these two values?

It could be better with configurable cache file path and ttl.